### PR TITLE
Stealthier location of hidden string

### DIFF
--- a/coolmit/__init__.py
+++ b/coolmit/__init__.py
@@ -8,9 +8,9 @@ from .cpu import CoolmitCPUMiner as BestCoolmitMiner
 def coolmit(root_path, prefix, message, chunk_size=100000, num_workers=5):
     """Makes your commit cooler."""
     miner = BestCoolmitMiner(root_path)
-    coolmit_msg, coolmit_salt, coolmit_hash = miner.mine(
+    coolmit_header, coolmit_body, coolmit_salt, coolmit_hash = miner.mine(
         prefix, message, chunk_size=chunk_size, num_workers=num_workers)
-    coolmit_msg += coolmit_salt
+    coolmit_msg = "{}{}{}".format(coolmit_header, coolmit_salt, coolmit_body)
     # HACK: I'd rather use the --stdin option but
     # it's not quite working so I dump it to a file.
     fname = os.path.join(root_path, ".coolmit")

--- a/coolmit/base.py
+++ b/coolmit/base.py
@@ -39,35 +39,36 @@ class CoolmitMiner(object):
             parent = ""
         timestamp = int(time.time())
         if parent:
-            body = """tree {tree}
+            header = """tree {tree}
 parent {parent}
 author {name} <{email}> {timestamp} -0600
 committer {name} <{email}> {timestamp} -0600
-
-{message}\n""".format(
-                tree=tree, parent=parent, timestamp=timestamp, message=message,
+gitfor """.format(
+                tree=tree, parent=parent, timestamp=timestamp,
                 name=user_name, email=user_email
             )
         else: # no parent commit
-            body = """tree {tree}
+            header = """tree {tree}
 author {name} <{email}> {timestamp} -0600
 committer {name} <{email}> {timestamp} -0600
-
-{message}\n""".format(
-                tree=tree, timestamp=timestamp, message=message,
+gitfor """.format(
+                tree=tree, timestamp=timestamp,
                 name=user_name, email=user_email
             )
-        return body
+        body = "\n\n{}".format(message) # newline after headers and blank line
+        return header, body
 
-    def prepare_git_object(self, body, probe_length):
+    def prepare_git_object(self, header, body, probe_length):
+        len_full = len(header) + len(body) + probe_length
         if self.message_alignment:
             while True:
-                msg = "commit {}\0{}".format(len(body) + probe_length, body)
+                msg = "commit {}\0{}{}".format(len_full + probe_length, header, body)
                 if (len(msg) + probe_length) % self.message_alignment:
-                    body += " "
+                    header += " "
+                    len_full = len(header) + len(body) + probe_length
                 else:
                     break
-        return "commit {}\0{}".format(len(body) + probe_length, body)
+        return "commit {}\0{}".format(len_full, header), header
 
     def pre_mine(self):
         pass
@@ -77,12 +78,13 @@ committer {name} <{email}> {timestamp} -0600
         result = None
         self.pre_mine()
         for probe_length in range(1, max_probe_length + 1):
-            coolmit_msg = self.prepare_message(message)
-            template = self.prepare_git_object(coolmit_msg, probe_length)
-            result = self._probe(prefix, template, probe_length, chunk_size)
+            coolmit_header, coolmit_body = self.prepare_message(message)
+            git_header, coolmit_header = self.prepare_git_object(coolmit_header, coolmit_body, probe_length)
+            result = self._probe(
+                prefix, git_header, coolmit_body, probe_length, chunk_size)
             if result:
                 salt, hash_ = result
-                return coolmit_msg, salt, hash_
+                return coolmit_header, coolmit_body, salt, hash_
 
-    def _probe(self, prefix, message, probe_length, chunk_size):
+    def _probe(self, prefix, header, body, probe_length, chunk_size):
         raise NotImplemented("Implement `_probe`")

--- a/coolmit/cpu.py
+++ b/coolmit/cpu.py
@@ -10,10 +10,10 @@ from .base import CoolmitMiner
 
 def coolmit_probe_worker(args):
     """Coolmit worker which helps find that cool commit hash you crave."""
-    prefix, msg_template, charset, worker_id, num_workers, start_offset, probe_length, work_chunk_size = args
+    prefix, msg_header, msg_body, charset, worker_id, num_workers, start_offset, probe_length, work_chunk_size = args
     hf = hashlib.sha1
     len_charset = len(charset)
-    msg_h = hf(msg_template)
+    msg_h = hf(msg_header)
     for i in xrange(start_offset + worker_id, start_offset + work_chunk_size, num_workers):
         salt = ''
         remaining = i
@@ -22,6 +22,7 @@ def coolmit_probe_worker(args):
             remaining = remaining // len_charset
         h = msg_h.copy()
         h.update(salt)
+        h.update(msg_body)
         h = h.hexdigest()
         if h.startswith(prefix):
             return salt, h
@@ -36,21 +37,21 @@ class CoolmitCPUMiner(CoolmitMiner):
     def pre_mine(self):
         self.pool = Pool(self.num_workers)
 
-    def _probe(self, prefix, message, probe_length, chunk_size):
+    def _probe(self, prefix, header, body, probe_length, chunk_size):
         work_chunk_size = self.num_workers * chunk_size
         num_combinations = len(self.charset) ** probe_length
-        
+
         start_offset = 0
         start_t = time.time()
         while start_offset < num_combinations:
             params = [
-                (prefix, message, self.charset, worker_id, self.num_workers, start_offset, probe_length, work_chunk_size) \
+                (prefix, header, body, self.charset, worker_id, self.num_workers, start_offset, probe_length, work_chunk_size) \
                 for worker_id in range(self.num_workers)
             ]
             results = self.pool.map(coolmit_probe_worker, params)
             for result in results:
-                if result:       
-                    return result 
+                if result:
+                    return result
             start_offset += work_chunk_size
             if start_offset % (work_chunk_size * 1) == 0:
                 dt = time.time() - start_t


### PR DESCRIPTION
Hides the string in the commit header. This is a little slower since we have to rehash the commit message body every time.